### PR TITLE
Fix hash calculation on python3

### DIFF
--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -101,7 +101,7 @@ function RPR_HOST() {
     local index=$(python <<EOF
 import hashlib
 
-hash = int(hashlib.sha1('$(hostname)').hexdigest(), 16)
+hash = int(hashlib.sha1('$(hostname)'.encode('ascii')).hexdigest(), 16)
 index = hash % ${#colors} + 1
 
 print(index)


### PR DESCRIPTION
I know you say not to fork dotfiles..

Fixes error when the default python is python3. When calculating the RCMD the following error is raised
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Unicode-objects must be encoded before hashing

Works under python2 and python3
