### PR TITLE
Update plugins_after.zsh

### DIFF
--- a/zsh/plugins_after.zsh
+++ b/zsh/plugins_after.zsh
@@ -33,5 +33,5 @@ fi
 # dircolors
 
 if [[ "$(tput colors)" == "256" ]]; then
-    eval $(dircolors =(cat ~/.shell/plugins/dircolors-solarized/dircolors.256dark ~/.shell/dircolors.extra))
+    eval $(gdircolors =(cat ~/.shell/plugins/dircolors-solarized/dircolors.256dark ~/.shell/dircolors.extra))
 fi


### PR DESCRIPTION
change 

dircolors to gdicolors new installation in Mac will print command not found because the new installation process brew install coreutils adds "g" to dircolors. 

Please refer to the following link: https://formulae.brew.sh/formula/coreutils